### PR TITLE
Minor/gefahr normal farbe anpassen

### DIFF
--- a/.changeset/selfish-singers-accept.md
+++ b/.changeset/selfish-singers-accept.md
@@ -1,0 +1,8 @@
+---
+"taktische-zeichen-core": patch
+"taktische-zeichen-cli": patch
+"taktische-zeichen-react": patch
+"taktische-zeichen-web-component": patch
+---
+
+Bei Grundzeichen "Gefahr" das Attribut "stroke" auf "currentColor" gesetzt damit die Farbe angepasst werden kann.

--- a/packages/core/src/grundzeichen.ts
+++ b/packages/core/src/grundzeichen.ts
@@ -451,7 +451,10 @@ export const grundzeichen: Array<Grundzeichen> = [
     size: [45, 36],
     accepts: ["symbol", "farbe"],
     ...singleShape((svg) =>
-      svg.path("M22.5,34 L43.2,1 H1.8 Z").attr("fill", "white")
+      svg
+        .path("M22.5,34 L43.2,1 H1.8 Z")
+        .attr("fill", "white")
+        .attr("stroke", "currentColor")
     ),
     padding: [5, 15, 15],
   },


### PR DESCRIPTION
# ❤️ Vielen Dank für deinen PR!

Grundzeichen Gefahr um das Attribute "stroke" erweitert, damit die Farbe angepasst werden kann.
## ✅ Checkliste

Bitte stelle sicher, dass du die folgenden Aufgaben für deinen PR erledeigt hast:

- [X] Changeset erstellt (siehe [Contributors' Guide](https://github.com/phjardas/taktische-zeichen/blob/main/CONTRIBUTING.md)).

  Verwende bitte die folgenden Versionsanpassungen:

  - Fehler korrigiert ➡️ `patch`
  - Neues Symbol hinzugefügt ➡️ `minor`
  - Nicht rückwärtskompatible Änderung ➡️ `major`

- [X] Dokumentation angepasst mit `npm run update-docs`.

## ⚖️ Lizenz

Durch das Einreichen dieses PRs erklärst du dich damit einverstanden, dass dein Code im Rahmen dieser Bibliothek unter einer MIT-Lizenz kostenlos veröffentlicht wird.
