### PR TITLE
Fix typo in cli example

### DIFF
--- a/.changeset/tender-swans-attend.md
+++ b/.changeset/tender-swans-attend.md
@@ -1,0 +1,6 @@
+---
+"taktische-zeichen-cli": patch
+"taktische-zeichen-website": patch
+---
+
+Fix typo in cli example grupp -> gruppe

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ taktisches-zeichen \
   --grundzeichen kraftfahrzeug-gelaendegaengig \
   --organisation feuerwehr \
   --fachaufgabe brandbekaempfung \
-  --einheit grupp
+  --einheit gruppe
 
 # Ausgabe auf STDOUT:
 # <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,7 +26,7 @@ taktisches-zeichen \
   --grundzeichen kraftfahrzeug-gelaendegaengig \
   --organisation feuerwehr \
   --fachaufgabe brandbekaempfung \
-  --einheit grupp
+  --einheit gruppe
 
 # Ausgabe:
 # <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/cli/USAGE.md
+++ b/packages/cli/USAGE.md
@@ -13,7 +13,7 @@ taktisches-zeichen \
   --grundzeichen kraftfahrzeug-gelaendegaengig \
   --organisation feuerwehr \
   --fachaufgabe brandbekaempfung \
-  --einheit grupp
+  --einheit gruppe
 
 # Ausgabe auf STDOUT:
 # <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/website/views/_includes/usage_cli.md
+++ b/packages/website/views/_includes/usage_cli.md
@@ -13,7 +13,7 @@ taktisches-zeichen \
   --grundzeichen kraftfahrzeug-gelaendegaengig \
   --organisation feuerwehr \
   --fachaufgabe brandbekaempfung \
-  --einheit grupp
+  --einheit gruppe
 
 # Ausgabe auf STDOUT:
 # <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
# ❤️ Vielen Dank für deinen PR!

Ein typo im cli example:

```
--einheit grupp
```

```
--einheit gruppe
```

## ✅ Checkliste

Bitte stelle sicher, dass du die folgenden Aufgaben für deinen PR erledeigt hast:

- [x] Changeset erstellt (siehe [Contributors' Guide](https://github.com/phjardas/taktische-zeichen/blob/main/CONTRIBUTING.md)).

  Verwende bitte die folgenden Versionsanpassungen:

  - Fehler korrigiert ➡️ `patch`
  - Neues Symbol hinzugefügt ➡️ `minor`
  - Nicht rückwärtskompatible Änderung ➡️ `major`

Ich hoffe, ich habe das richtig gemacht.

- [ ] Dokumentation angepasst mit `npm run update-docs`.

Lief leider nicht.

## ⚖️ Lizenz

Durch das Einreichen dieses PRs erklärst du dich damit einverstanden, dass dein Code im Rahmen dieser Bibliothek unter einer MIT-Lizenz kostenlos veröffentlicht wird.
